### PR TITLE
🐛 Remove DB migration timeout

### DIFF
--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing-setup/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing-setup/run
@@ -16,17 +16,10 @@ fi
 bashio::log.info "Waiting for Syncthing to be reachable..."
 bashio::net.wait_for 8384 "$ip"
 
-bashio::log.info "Checking Syncthing health..."
-max_retries=2160  # Wait up to 6 hours (2160 * 10s)
-retries=0
+bashio::log.info "Waiting for Syncthing to be healthy..."
 until curl --insecure -s "http://$ip:8384/rest/noauth/health" | grep -o --color=never "OK"; do
-  retries=$((retries + 1))
-  if [ "$retries" -ge "$max_retries" ]; then
-    bashio::log.error "Syncthing did not become healthy after $((max_retries * 10)) seconds. Exiting."
-    exit 1
-  fi
-  bashio::log.info "Syncthing not yet healthy, waiting... (attempt $retries/$max_retries)"
-  sleep 10
+  bashio::log.info "Syncthing not yet healthy, still waiting (see Ingress output for possible DB migration progress)..."
+  sleep 15
 done
 
 bashio::log.info 'Post-Start syncthing setup'


### PR DESCRIPTION
~~Increases DB migration timeout from 5min to 6h, so larger setups on lower-end devices have a chance to finish the migration successfully.~~ *Completely removes our custom timeout since it breaks DB migration for large setups as it was based on idle speculation.*

The current 5min timeout was wayyy too low for my setup (600GiB+ in 10 receive-encrypted folders on ODROID-M1 (ARM Cortex-A55; 8 GiB RAM)).