### PR TITLE
⬆️ Update Alpine Linux to 3.22

### DIFF
--- a/syncthing/build.yaml
+++ b/syncthing/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  armhf: ghcr.io/home-assistant/armhf-base:3.20
-  armv7: ghcr.io/home-assistant/armv7-base:3.20
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
-  amd64: ghcr.io/home-assistant/amd64-base:3.20
-  i386: ghcr.io/home-assistant/i386-base:3.20
+  armhf: ghcr.io/home-assistant/armhf-base:3.22
+  armv7: ghcr.io/home-assistant/armv7-base:3.22
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.22
+  amd64: ghcr.io/home-assistant/amd64-base:3.22
+  i386: ghcr.io/home-assistant/i386-base:3.22


### PR DESCRIPTION
Depends on https://github.com/Poeschl-HomeAssistant-Addons/syncthing/pull/26.