### PR TITLE
⬆️ Update syncthing to 2.0.15-r0

### DIFF
--- a/syncthing/Dockerfile
+++ b/syncthing/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-		"syncthing=2.0.14-r0"
+		"syncthing=2.0.15-r0"
 
 COPY root /
 RUN chmod +x /etc/s6-overlay/s6-rc.d/syncthing-setup/run


### PR DESCRIPTION
Addon-Botter is still [running into merge conflicts](https://github.com/Poeschl-HomeAssistant-Addons/syncthing/actions/runs/23033884360/job/66913405634#step:6:38) when trying to update the `Dockerfile`...